### PR TITLE
Name check should be exact, not globbed

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
     end
 
     if name = hash[:justme]
-      command << name + "$"
+      command << '^' + name + '$'
     end
 
     list = []


### PR DESCRIPTION
The name check for an installed gem should be exact and not globbed. Right now a specification for "redis" would match both the "hiredis" and "redis" gems. 