### PR TITLE
allow override to not install mod_passenger if just installing the gem

### DIFF
--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -9,6 +9,7 @@ class rvm::passenger::apache(
   $maxinstancesperapp = '0',
   $spawnmethod = 'smart-lv2',
   $proxy_url = undef,
+  $package_ensure = undef,
   $install_timeout = 600
 ) {
 
@@ -67,6 +68,7 @@ class rvm::passenger::apache(
     passenger_max_pool_size  => $maxpoolsize,
     passenger_pool_idle_time => $poolidletime,
     mod_lib_path             => $modpath,
+    mod_package_ensure       => $package_ensure,
     require                  => [ Exec['passenger-install-apache2-module'], File['passenger_module_object'], ],
     subscribe                => Exec['passenger-install-apache2-module'],
   }


### PR DESCRIPTION
If installing passenger via the gem, this would allow someone to not have to install mod_passenger.