### PR TITLE
Use which to test for gpg2

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -35,11 +35,11 @@ class rvm::system(
 
   # ignore gpg check if it is not installed, same as rvm does
   exec { 'system-rvm-gpg-key':
-    command     => 'gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3',
+    command     => 'which gpg2 && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3',
     path        => $::path,
     environment => $environment,
-    unless      => 'gpg2 --list-keys D39DC0E3',
-    onlyif      => ['gpg2 --version'],
+    unless      => 'which gpg2 && gpg2 --list-keys D39DC0E3',
+    onlyif      => 'which gpg2',
   } ->
 
   exec { 'system-rvm':


### PR DESCRIPTION
Running gpg2 directly fails on systems without this command.  Puppet pre checks for commands in the path.