### PR TITLE
Add Darwin gnupg2 dependency

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class rvm::params($manage_group = true) {
 
   $gpg_package = $::osfamily ? {
     /(Debian|RedHat)/ => 'gnupg2',
-    default => undef,
+    /Darwin/          => 'gnupg2',
+    default           => undef,
   }
 }


### PR DESCRIPTION
This package works great on Darwin / OS X to install system-wide rvm, but will fail if gnupg2 isn't already installed because that dependency was missing. Just a quick PR to fix that.

Cheers,

Brandon