### PR TITLE
Fixes #80 - CentOS 7 libcurl-devel dependency

### DIFF
--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -7,7 +7,7 @@ class rvm::dependencies::centos {
   }
 
   case $version {
-    /^6\..*/: {
+    /^[67]\..*/: {
       ensure_packages(['libcurl-devel'])
     }
     /^5\..*/: {

--- a/manifests/passenger/dependencies/centos.pp
+++ b/manifests/passenger/dependencies/centos.pp
@@ -7,7 +7,7 @@ class rvm::passenger::dependencies::centos {
   }
 
   case $version {
-    /^6\..*/: {
+    /^[67]\..*/: {
       ensure_packages(['libcurl-devel'])
     }
     default: {


### PR DESCRIPTION
This was the least impactful way to fix this so that it works for CentOS/RHEL 7 without changing the logic entirely.