### PR TITLE
shell provider to exec so Puppet doesn't complain about resolving path

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -40,6 +40,7 @@ class rvm::system(
     environment => $environment,
     unless      => 'which gpg && gpg --list-keys D39DC0E3',
     onlyif      => 'which gpg',
+    provider    => shell
   } ->
 
   exec { 'system-rvm':


### PR DESCRIPTION
Elsewise it will sometimes complain about wanting us to qualify the command or specify a path