### PR TITLE
Added option to specify the key_server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,8 @@ class rvm(
   $system_users=[],
   $system_rubies={},
   $proxy_url=$rvm::params::proxy_url,
-  $no_proxy=$rvm::params::no_proxy) inherits rvm::params {
+  $no_proxy=$rvm::params::no_proxy,
+  $key_server=$rvm::params::key_server) inherits rvm::params {
 
   if $install_rvm {
 
@@ -23,9 +24,10 @@ class rvm(
     }
 
     class { 'rvm::system':
-      version   => $version,
-      proxy_url => $proxy_url,
-      no_proxy  => $no_proxy,
+      version    => $version,
+      proxy_url  => $proxy_url,
+      no_proxy   => $no_proxy,
+      key_server => $key_server
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class rvm::params($manage_group = true) {
 
   $proxy_url = undef
   $no_proxy = undef
+  $key_server = 'keys.gnupg.net'
 
   $gpg_package = $::kernel ? {
     /(Linux|Darwin)/ => 'gnupg2',

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -3,6 +3,7 @@ class rvm::system(
   $version=undef,
   $proxy_url=undef,
   $no_proxy=undef,
+  $key_server=undef,
   $home=$::root_home) {
 
   $actual_version = $version ? {
@@ -35,7 +36,7 @@ class rvm::system(
 
   # ignore gpg check if it is not installed, same as rvm does
   exec { 'system-rvm-gpg-key':
-    command     => 'which gpg && gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3',
+    command     => "which gpg && gpg --keyserver hkp://${key_server} --recv-keys D39DC0E3",
     path        => '/usr/bin:/usr/sbin:/bin',
     environment => $environment,
     unless      => 'which gpg && gpg --list-keys D39DC0E3',


### PR DESCRIPTION
I've been having lots of trouble with a Debian 7 Vagrant box build not adding the key. Using `keyserver.ubuntu.com` rather than `keys.gnupg.net` works fine, I've no idea why. I've been pragmatic and added the option to specify this.

It's a non disruptive change which could be useful for other users. Let me know if you require other changes for this to be merged.
