### PR TITLE
Convert arguments to string before checking if they are empty

### DIFF
--- a/templates/rvmrc.erb
+++ b/templates/rvmrc.erb
@@ -1,12 +1,12 @@
-<% if @umask and !@umask.empty? -%>
+<% if @umask and !@umask.to_s.empty? -%>
 umask <%= @umask %>
 <% end -%>
-<% if @max_time_flag and !@max_time_flag.empty? -%>
+<% if @max_time_flag and !@max_time_flag.to_s.empty? -%>
 export rvm_max_time_flag=<%= @max_time_flag %>
 <% end -%>
-<% if @autoupdate_flag and !@autoupdate_flag.empty? -%>
+<% if @autoupdate_flag and !@autoupdate_flag.to_s.empty? -%>
 rvm_autoupdate_flag=<%= @autoupdate_flag %>
 <% end -%>
-<% if @silence_path_mismatch_check_flag and !@silence_path_mismatch_check_flag.empty? -%>
+<% if @silence_path_mismatch_check_flag and !@silence_path_mismatch_check_flag.to_s.empty? -%>
 rvm_silence_path_mismatch_check_flag=<%= @silence_path_mismatch_check_flag %>
 <%end -%>


### PR DESCRIPTION
This was failing in Puppet 4 as `umask`, `max_time_flag`, `autoupdate_flag`, `silence_path_mismatch_check_flag` could be `Fixnum` and don't have the `empty?` method.

This feels like a bit of a hack, but I can't think of a (simple) alternative.