### PR TITLE
System user and group

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -1,4 +1,7 @@
 # Create the RVM group
 class rvm::group inherits rvm::params {
-  ensure_resource('group', $rvm::params::group, {'ensure' => 'present' })
+  ensure_resource('group', $rvm::params::group, {
+    'ensure' => 'present',
+    'system' => true,
+  })
 }

--- a/manifests/system_user.pp
+++ b/manifests/system_user.pp
@@ -11,7 +11,10 @@ define rvm::system_user (
   }
 
   if $create {
-    ensure_resource('user', $name, {'ensure' => 'present' })
+    ensure_resource('user', $name, {
+      'ensure' => 'present',
+      'system' => true,
+    })
     User[$name] -> Exec["rvm-system-user-${name}"]
   }
 


### PR DESCRIPTION
It is common practice to use different UID/GID ranges for human users and groups vs users and groups used for services. Adding the users and groups as system users and groups ensures this.

Many distros do this as well when a user or group is created by a package. For example, see https://www.debian.org/doc/debian-policy/ch-opersys.html#s9.2