### PR TITLE
Removing Puppetfile from repository.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,5 +1,0 @@
-forge 'http://forge.puppetlabs.com'
-
-metadata
-
-mod 'puppetlabs/apache', '>= 1.1.0'


### PR DESCRIPTION
The Puppetfile contains the mod puppetlabs/apache, which is causing apache to be still installed when the module is used with puppet-librarian. Removing Puppetfile will cause apache to be no longer installed by the librarian.