### PR TITLE
Include ruby- prefix in hiera example.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -187,9 +187,9 @@ and using:
 You can configure the ruby versions to be installed and the system users from hiera
 
     rvm::system_rubies:
-      '1.9':
+      'ruby-1.9':
         default_use: true
-      '2.0': {}
+      'ruby-2.0': {}
       'jruby-1.7': {}
 
     rvm::system_users:
@@ -199,7 +199,7 @@ You can configure the ruby versions to be installed and the system users from hi
     rvm::rvm_gems:
       'bundler':
         name: 'bundler'
-        ruby_version: '1.9'
+        ruby_version: 'ruby-1.9'
         ensure: latest
 
 


### PR DESCRIPTION
I'm trying to get RVM with passenger working; and I started with the heira syntax.  What I've found is that the passenger support requires (1) you to be consistent with either using or omitting the ruby- prefix in order to get started, and (2) ultimately you need to include the ruby- prefix as that's what's included in the generated Apache configuration.  To save others a bit of time, I suggest updating the docs to include the prefix in the hiera example.