### PR TITLE
Allow rvm to mount a Ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ vendor/
 .rvmrc*
 .ruby-*
 
+# IntelliJ/RubyMine
+.idea/*
+
 ## rspec
 spec/fixtures/manifests/
 spec/fixtures/modules/

--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -6,19 +6,10 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   end
 
   def create
-    unless resource[:proxy_url].nil?
-      ENV['http_proxy'] = resource[:proxy_url]
-      ENV['https_proxy'] = resource[:proxy_url]
-      unless resource[:no_proxy].nil?
-        ENV['no_proxy'] = resource[:no_proxy]
-      end
-    end
-    set_autolib_mode if resource.value(:autolib_mode)
-    options = Array(resource[:build_opts])
-    if resource[:proxy_url] and !resource[:proxy_url].empty?
-      rvmcmd "install", resource[:name], "--proxy", resource[:proxy_url], *options
+    if resource[:mount_from]
+      mount
     else
-      rvmcmd "install", resource[:name], *options
+      install
     end
     set_default if resource.value(:default_use)
   end
@@ -62,5 +53,28 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not set autolib mode: #{detail}"
     end
+  end
+
+  private
+
+  def install
+    unless resource[:proxy_url].nil?
+      ENV['http_proxy']  = resource[:proxy_url]
+      ENV['https_proxy'] = resource[:proxy_url]
+      unless resource[:no_proxy].nil?
+        ENV['no_proxy'] = resource[:no_proxy]
+      end
+    end
+    set_autolib_mode if resource.value(:autolib_mode)
+    options = Array(resource[:build_opts])
+    if resource[:proxy_url] and !resource[:proxy_url].empty?
+      rvmcmd "install", resource[:name], "--proxy", resource[:proxy_url], *options
+    else
+      rvmcmd "install", resource[:name], *options
+    end
+  end
+
+  def mount
+    rvmcmd "mount", resource[:mount_from]
   end
 end

--- a/lib/puppet/type/rvm_system_ruby.rb
+++ b/lib/puppet/type/rvm_system_ruby.rb
@@ -32,4 +32,8 @@ Puppet::Type.newtype(:rvm_system_ruby) do
     desc "Set RVM autolib mode"
   end
 
+  newparam(:mount_from) do
+    desc 'If you wish to specify a Ruby archive to mount'
+  end
+
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 # Install RVM, create system user a install system level rubies
 class rvm(
   $version=undef,
+  $install_from=undef,
   $install_rvm=true,
   $install_dependencies=false,
   $manage_rvmrc=$rvm::params::manage_rvmrc,
@@ -31,6 +32,7 @@ class rvm(
       no_proxy     => $no_proxy,
       key_server   => $key_server,
       gnupg_key_id => $gnupg_key_id,
+      install_from => $install_from,
     }
   }
 


### PR DESCRIPTION
Allows RVM to mount a Ruby archive this is useful when you have a specific build you wish to mount and especially useful when your target host is not able to make outbound connections.