### PR TITLE
Update project url and source to use HTTPS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,8 +4,8 @@
   "author": "maestrodev & Brandon Turner <bt@brandonturner.net>",
   "summary": "A puppet module for installing and using RVM (Ruby Version Manager)",
   "license": "Modified BSD License",
-  "source": "http://github.com/maestrodev/puppet-rvm",
-  "project_page": "http://github.com/maestrodev/puppet-rvm",
+  "source": "https://github.com/maestrodev/puppet-rvm",
+  "project_page": "https://github.com/maestrodev/puppet-rvm",
   "issues_url": "https://github.com/maestrodev/puppet-rvm/issues",
   "description": "Installing and using RVM (Ruby Version Manager)",
   "dependencies": [


### PR DESCRIPTION
Git clones of http do not follow the https redirect github provides.