### PR TITLE
Fix idempotency error when using latest.

### DIFF
--- a/lib/puppet/type/rvm_gem.rb
+++ b/lib/puppet/type/rvm_gem.rb
@@ -86,7 +86,7 @@ Puppet::Type.newtype(:rvm_gem) do
           end
 
           case is
-          when is.is_a?(Array)
+          when Array
             if is.include?(@latest)
               return true
             else


### PR DESCRIPTION
This tiny patch fix the problem of idempotency (gem is always reinstalled) when using ensure => latest (Issue #114).

The is.is_a? can not be used in a case/when statement if the "case" already applies to 'is'.