### PR TITLE
Convert rvm_system_ruby autolib_mode to parameter

### DIFF
--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -47,14 +47,6 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
     rvmcmd "alias", "create", "default", resource[:name]
   end
 
-  def set_autolib_mode
-    begin
-      rvmcmd "autolibs", resource[:autolib_mode]
-    rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, "Could not set autolib mode: #{detail}"
-    end
-  end
-
   private
 
   def install
@@ -65,8 +57,10 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
         ENV['no_proxy'] = resource[:no_proxy]
       end
     end
-    set_autolib_mode if resource.value(:autolib_mode)
     options = Array(resource[:build_opts])
+    if resource[:autolibs_mode]
+      options << "--autolibs #{resource[:autolibs_mode]}"
+    end
     if resource[:proxy_url] and !resource[:proxy_url].empty?
       rvmcmd "install", resource[:name], "--proxy", resource[:proxy_url], *options
     else

--- a/lib/puppet/type/rvm_system_ruby.rb
+++ b/lib/puppet/type/rvm_system_ruby.rb
@@ -28,8 +28,20 @@ Puppet::Type.newtype(:rvm_system_ruby) do
     defaultto false
   end
 
-  newproperty(:autolib_mode) do
-    desc "Set RVM autolib mode"
+  newparam(:autolib_mode) do
+    desc "Set RVM autolib mode for the Ruby installation"
+
+    validate do |value|
+      modes = [
+        0, 'disable', 'disabled',
+        1, 'read', 'read-only',
+        2, 'fail', 'read-fail',
+        3, 'packages', 'install-packages',
+        4, 'enable', 'enabled',
+      ]
+
+      fail("Invalid autolib mode: #{value}") unless modes.include? value
+    end
   end
 
   newparam(:mount_from) do

--- a/spec/unit/puppet/type/rvm_system_ruby_spec.rb
+++ b/spec/unit/puppet/type/rvm_system_ruby_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'puppet'
+require 'puppet/type/rvm_system_ruby'
+
+describe Puppet::Type.type(:rvm_system_ruby) do
+  context 'with autolib_mode set' do
+    it 'should not raise error' do
+      expect do
+        Puppet::Type.type(:rvm_system_ruby).new(:name => 'ruby-1.9.3-p448', :autolib_mode => 'enabled')
+      end.not_to raise_error
+    end
+
+    it 'should set mode correctly' do
+      @system_ruby = Puppet::Type.type(:rvm_system_ruby).new(:name => 'jruby-1.7.6', :autolib_mode => 'read-fail')
+      expect(@system_ruby[:autolib_mode]).to eq('read-fail')
+    end
+  end
+
+  it 'should error on an incorrect autolib_mode' do
+    expect do
+      Puppet::Type.type(:rvm_system_ruby).new(:name => 'ruby-1.9.3-p448', :autolib_mode => 'foo')
+    end.to raise_error(Puppet::ResourceError, /Invalid autolib mode: foo/)
+  end
+end


### PR DESCRIPTION
This should be a parameter that affects whether the --autolibs argument
is passed to the `rvm install` command and what its value is. Currently `autolib_mode` is a property and affects autolibs globally. This caused an error on PE 2015.3.3/Puppet 4.3.2 since there were no getter/setter methods defined for the property.