### PR TITLE
Avoid warn with puppet4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class rvm::params($manage_group = true) {
   $key_server = 'hkp://keys.gnupg.net'
 
   # install the gpg key if gpg is installed or being installed in this puppet run
-  if defined(Class['::gnupg']) or $::gnupg_installed {
+  if defined(Class['::gnupg']) or $facts['gnupg_installed'] {
     $gnupg_key_id = 'D39DC0E3'
   } else {
     $gnupg_key_id = false


### PR DESCRIPTION
"gnupg_installed" fact is not present by default, and we got this message in puppet4 server log :
WARN  [puppetserver] Puppet Unknown variable: '::gnupg_installed'. at 

An idea is to use the $facts['fact_name'] :
https://docs.puppet.com/puppet/4.10/lang_facts_and_builtin_vars.html#the-factsfactname-hash